### PR TITLE
[skip ci]: Enabled Data persistence in volume istgt and mgmt kill in konvoy release branch

### DIFF
--- a/openebs-konvoy-e2e/pipelines/OpenEBS-base/stages/4-chaos/CUVR-cstor-volume-istgt-kill/cstor-volume-istgt-kill
+++ b/openebs-konvoy-e2e/pipelines/OpenEBS-base/stages/4-chaos/CUVR-cstor-volume-istgt-kill/cstor-volume-istgt-kill
@@ -112,25 +112,36 @@ run_id="istgt";test_name=$(bash openebs-konvoy-e2e/utils/generate_test_name test
 echo $test_name
 
 cd litmus
-cp experiments/chaos/openebs_target_failure/run_litmus_test.yml run_targetistgt_kill_test.yml
+cp experiments/chaos/openebs_target_failure/run_litmus_test.yml run_target_istgt_kill_test.yml
 
 sed -i -e 's/value: percona-mysql-claim/value: openebs-bb-istgt-targetkill/g' \
+-e 's/name: target-failure/name: target-istgt-kill/g' \
 -e 's/name: openebs-target-failure/name: openebs-target-istgt-failure/g' \
 -e 's/target-zrepl-kill/target-kill/g' \
 -e 's/cstor-volume-mgmt/cstor-istgt/g' \
 -e 's/value: openebs-cstor-sparse/value: openebs-cstor-disk/g' \
 -e 's/value: '\''name=percona'\''/value: '\''app=istgt-kill'\''/g' \
--e 's/value: app-percona-ns/value: istgt-kill/g' run_targetistgt_kill_test.yml
+-e 's/value: app-percona-ns/value: istgt-kill/g' run_target_istgt_kill_test.yml
 
 sed -i '/command:/i \
           - name: RUN_ID\
             value: '"$run_id"'\
-' run_targetistgt_kill_test.yml
+' run_target_istgt_kill_test.yml
+
+## Replace the value of DATA_PERSISTENCE with application name in litmus experiment. 
+sed -i '/name: DATA_PERSISTENCE/{n;s/.*/            value: busybox/}' run_target_istgt_kill_test.yml
+
+## Insert the set of variables for busybox data consistency util into configmap spec.
+sed -i '/parameters.yml: |/a \
+    blocksize: 4k\
+    blockcount: 1024\
+    testfile: targetistgtkilltest
+' run_target_istgt_kill_test.yml
 
 echo "Running the litmus test for Busybox Deployment Scaleup.."
-cat run_targetistgt_kill_test.yml
+cat run_target_istgt_kill_test.yml
 
-bash ../openebs-konvoy-e2e/utils/litmus_job_runner label='name:openebs-target-istgt-failure' job=run_targetistgt_kill_test.yml
+bash ../openebs-konvoy-e2e/utils/litmus_job_runner label='name:openebs-target-istgt-failure' job=run_target_istgt_kill_test.yml
 cd ..
 bash openebs-konvoy-e2e/utils/dump_cluster_state;
 bash openebs-konvoy-e2e/utils/event_updater jobname:target-istgt-kill $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"

--- a/openebs-konvoy-e2e/pipelines/OpenEBS-base/stages/4-chaos/ENEY-cstor-volume-mgmt-kill/cstor-volume-mgmt-kill
+++ b/openebs-konvoy-e2e/pipelines/OpenEBS-base/stages/4-chaos/ENEY-cstor-volume-mgmt-kill/cstor-volume-mgmt-kill
@@ -131,22 +131,33 @@ run_id="mgmt";test_name=$(bash openebs-konvoy-e2e/utils/generate_test_name testc
 echo $test_name
 
 cd litmus
-cp experiments/chaos/openebs_target_failure/run_litmus_test.yml run_targetmgmt_kill_test.yml
+cp experiments/chaos/openebs_target_failure/run_litmus_test.yml run_target_mgmt_kill_test.yml
 
 sed -i -e 's/value: percona-mysql-claim/value: openebs-bb-mgmt-targetkill/g' \
+-e 's/name: target-failure/name: target-mgmt-kill/g' \
 -e 's/name: openebs-target-failure/name: openebs-target-mgmt-failure/g' \
 -e 's/value: '\''name=percona'\''/value: '\''app=target-mgmt-kill'\''/g' \
--e 's/value: app-percona-ns/value: mgmt-kill/g' run_targetmgmt_kill_test.yml
+-e 's/value: app-percona-ns/value: mgmt-kill/g' run_target_mgmt_kill_test.yml
 
 sed -i '/command:/i \
           - name: RUN_ID\
             value: '"$run_id"'\
-' run_targetmgmt_kill_test.yml
+' run_target_mgmt_kill_test.yml
+
+## Replace the value of DATA_PERSISTENCE with application name in litmus experiment. 
+sed -i '/name: DATA_PERSISTENCE/{n;s/.*/            value: busybox/}' run_target_mgmt_kill_test.yml
+
+## Insert the set of variables for busybox data consistency util into configmap spec.
+sed -i '/parameters.yml: |/a \
+    blocksize: 4k\
+    blockcount: 1024\
+    testfile: targetmgmtkilltest
+' run_target_mgmt_kill_test.yml
 
 # Running the litmus test for Busybox Deployment Scaleup
-cat run_targetmgmt_kill_test.yml
+cat run_target_mgmt_kill_test.yml
 
-bash ../openebs-konvoy-e2e/utils/litmus_job_runner label='name:openebs-target-mgmt-failure' job=run_targetmgmt_kill_test.yml
+bash ../openebs-konvoy-e2e/utils/litmus_job_runner label='name:openebs-target-mgmt-failure' job=run_target_mgmt_kill_test.yml
 cd ..
 bash openebs-konvoy-e2e/utils/dump_cluster_state;
 bash openebs-konvoy-e2e/utils/event_updater jobname:target-mgmt-kill $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"


### PR DESCRIPTION

Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>
1. Enabled data persistence in volume istgt kill test.
2. Enabled data persistence in volume mgmt kill test.
3. Modified the config-map names specific to the chaos.