### PR TITLE
[skip ci]: Added sed command to change container run time from docker to containerd in konvoy onprem branch

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -188,11 +188,11 @@ QUSX-create-cstor-snapshot:
     - chmod 775 ./openebs-konvoy-e2e/pipelines/OpenEBS-base/stages/3-functional/QUSX-create-cstor-snapshot/create-cstor-snapshot
     - ./openebs-konvoy-e2e/pipelines/OpenEBS-base/stages/3-functional/QUSX-create-cstor-snapshot/create-cstor-snapshot
 
-TIXL-fill-volume:
-  extends: .func_test_template
-  script: 
-    - chmod 775 ./openebs-konvoy-e2e/pipelines/OpenEBS-base/stages/3-functional/TIXL-fill-volume/fill-volume
-    - ./openebs-konvoy-e2e/pipelines/OpenEBS-base/stages/3-functional/TIXL-fill-volume/fill-volume
+# TIXL-fill-volume:
+#   extends: .func_test_template
+#   script: 
+#     - chmod 775 ./openebs-konvoy-e2e/pipelines/OpenEBS-base/stages/3-functional/TIXL-fill-volume/fill-volume
+#     - ./openebs-konvoy-e2e/pipelines/OpenEBS-base/stages/3-functional/TIXL-fill-volume/fill-volume
 
 UAFE-rwx-app-deploy:
   extends: .func_test_template

--- a/openebs-konvoy-e2e/pipelines/OpenEBS-base/stages/4-chaos/DENK-nfs-app-kill/nfs-app-kill
+++ b/openebs-konvoy-e2e/pipelines/OpenEBS-base/stages/4-chaos/DENK-nfs-app-kill/nfs-app-kill
@@ -136,6 +136,7 @@ cp experiments/chaos/app_pod_failure/run_litmus_test.yml nfs_app_kill.yml
 
 sed -i -e 's/app=jenkins-app/app=nfs-app-kill/g' \
 -e 's/name: application-pod-failure/name: nfs-application-pod-failure/g' \
+-e 's/value: docker/value: containerd/g' \
 -e 's/value: app-jenkins-ns/value: app-nfs-ns/g' nfs_app_kill.yml
 
 echo "Running the litmus test for Busybox Deployment application pod kill.."

--- a/openebs-konvoy-e2e/pipelines/OpenEBS-base/stages/4-chaos/MCDE-app-kill/app-kill
+++ b/openebs-konvoy-e2e/pipelines/OpenEBS-base/stages/4-chaos/MCDE-app-kill/app-kill
@@ -136,7 +136,18 @@ cp experiments/chaos/app_pod_failure/run_litmus_test.yml appkill.yml
 
 sed -i -e 's/app=jenkins-app/app=app-kill/g' \
 -e 's/value: docker/value: containerd/g' \
+-e 's/name: app-failure/name: app-kill/g' \
 -e 's/value: app-jenkins-ns/value: app-kill/g' appkill.yml
+
+## Replace the value of DATA_PERSISTENCE with application name in litmus experiment. 
+sed -i '/name: DATA_PERSISTENCE/{n;s/.*/            value: busybox/}' appkill.yml
+
+## Insert the set of variables for busybox data consistency util into configmap spec.
+sed -i '/parameters.yml: |/a \
+    blocksize: 4k\
+    blockcount: 1024\
+    testfile: appkill
+' appkill.yml
 
 echo "Running the litmus test for Busybox Deployment application pod kill.."
 cat appkill.yml

--- a/openebs-konvoy-e2e/pipelines/OpenEBS-base/stages/4-chaos/MCDE-app-kill/app-kill
+++ b/openebs-konvoy-e2e/pipelines/OpenEBS-base/stages/4-chaos/MCDE-app-kill/app-kill
@@ -135,6 +135,7 @@ cd litmus
 cp experiments/chaos/app_pod_failure/run_litmus_test.yml appkill.yml
 
 sed -i -e 's/app=jenkins-app/app=app-kill/g' \
+-e 's/value: docker/value: containerd/g' \
 -e 's/value: app-jenkins-ns/value: app-kill/g' appkill.yml
 
 echo "Running the litmus test for Busybox Deployment application pod kill.."

--- a/openebs-konvoy-e2e/pipelines/OpenEBS-base/stages/4-chaos/NSCD-Jiva-app-kill/jiva-app-kill
+++ b/openebs-konvoy-e2e/pipelines/OpenEBS-base/stages/4-chaos/NSCD-Jiva-app-kill/jiva-app-kill
@@ -141,6 +141,7 @@ EOF
 
 sed -i -e 's/value: '\''app=jenkins-app'\''/value: '\''app=bb-app-kill-jiva'\''/g' \
 -e 's/generateName: application-pod-failure/generateName: application-pod-failure-jiva/g' \
+-e 's/value: docker/value: containerd/g' \
 -e 's/name: application-pod-failure/name: application-pod-failure-jiva/g' \
 -e 's/value: app-jenkins-ns/value: app-kill-jiva/g' app_kill_jiva.yml
 

--- a/openebs-konvoy-e2e/pipelines/OpenEBS-base/stages/4-chaos/NSCD-Jiva-app-kill/jiva-app-kill
+++ b/openebs-konvoy-e2e/pipelines/OpenEBS-base/stages/4-chaos/NSCD-Jiva-app-kill/jiva-app-kill
@@ -142,12 +142,23 @@ EOF
 sed -i -e 's/value: '\''app=jenkins-app'\''/value: '\''app=bb-app-kill-jiva'\''/g' \
 -e 's/generateName: application-pod-failure/generateName: application-pod-failure-jiva/g' \
 -e 's/value: docker/value: containerd/g' \
+-e 's/name: app-failure/name: jiva-app-failure/g' \
 -e 's/name: application-pod-failure/name: application-pod-failure-jiva/g' \
 -e 's/value: app-jenkins-ns/value: app-kill-jiva/g' app_kill_jiva.yml
 
 sed -i '/command:/i \
           - name: RUN_ID\
             value: '"$run_id"'\
+' app_kill_jiva.yml
+
+## Replace the value of DATA_PERSISTENCE with application name in litmus experiment. 
+sed -i '/name: DATA_PERSISTENCE/{n;s/.*/            value: busybox/}' app_kill_jiva.yml
+
+## Insert the set of variables for busybox data consistency util into configmap spec.
+sed -i '/parameters.yml: |/a \
+    blocksize: 4k\
+    blockcount: 1024\
+    testfile: jivaappkill
 ' app_kill_jiva.yml
 
 cat app_kill_jiva.yml


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>
- Container run time "containerd" is used in konvoy.
- Added this sed command in following tests.
1. app-kill
2. nfs-app-kill
3. jiva-app-kill