### PR TITLE
[skip ci]: Modified gitlab script for cspc-pool-replace-bd to resolve typo in testcase name

### DIFF
--- a/openebs-konvoy-e2e/pipelines/OpenEBS-base/stages/3-functional/ESML-cstor-cspc-pool-expansion/cstor-cspc-pool-expansion
+++ b/openebs-konvoy-e2e/pipelines/OpenEBS-base/stages/3-functional/ESML-cstor-cspc-pool-expansion/cstor-cspc-pool-expansion
@@ -149,7 +149,7 @@ sed -i -e '/name: POOL_NAME/{n;s/.*/            value: cstor-cspc-mirror-pool/}'
 
 cat pool_expansion.yml
 
-bash ../openebs-konvoy-e2e/utils/litmus_job_runner label='app:cstor-cspc-pool-expansion' job=pool_scaleup.yml
+bash ../openebs-konvoy-e2e/utils/litmus_job_runner label='app:cstor-cspc-pool-expansion' job=pool_expansion.yml
 cd ..
 bash openebs-konvoy-e2e/utils/dump_cluster_state;
 bash openebs-konvoy-e2e/utils/event_updater jobname:cstor-cspc-pool-expansion $test_name jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id"
@@ -194,7 +194,7 @@ sed -i '/command:/i \
 
 cat cspc_expansion_verify_data_persistence.yml
 
-bash ../openebs-konvoy-e2e/utils/litmus_job_runner label='name:data-persistence-cspc-expansion-verify' job=bb_deployment_cstor_verify_data_persistence.yml
+bash ../openebs-konvoy-e2e/utils/litmus_job_runner label='name:data-persistence-cspc-expansion-verify' job=cspc_expansion_verify_data_persistence.yml
 cd ..
 
 bash openebs-konvoy-e2e/utils/dump_cluster_state;

--- a/openebs-konvoy-e2e/pipelines/OpenEBS-base/stages/3-functional/JULL-cstor-cspc-pool-replace-blockdevice/cstor-cspc-pool-replace-blockdevice
+++ b/openebs-konvoy-e2e/pipelines/OpenEBS-base/stages/3-functional/JULL-cstor-cspc-pool-replace-blockdevice/cstor-cspc-pool-replace-blockdevice
@@ -28,7 +28,7 @@ bash openebs-konvoy-e2e/utils/e2e-cr jobname:cstor-cspc-pool-replace-blockdevice
 
 echo "****Deploying busybox Application using CSI****"
 
-test_name=$(bash openebs-konvoy-e2e/utils/generate_test_name testcase=busybox-provision-repalce-blockdevice metadata='')
+test_name=$(bash openebs-konvoy-e2e/utils/generate_test_name testcase=busybox-provision-replace-blockdevice metadata='')
 echo $test_name
 
 cd litmus

--- a/openebs-konvoy-e2e/utils/litmus_job_runner
+++ b/openebs-konvoy-e2e/utils/litmus_job_runner
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -x
-
+job_retry_count=0
+container_retry_count=0
+job_state_retry_count=0
 litmus_job_label_key=$(echo $1 | cut -d "=" -f 2 | cut -d ":" -f 1)
 litmus_job_label_value=$(echo $1 | cut -d "=" -f 2 | cut -d ":" -f 2)
 litmus_job_file=$(echo $2 | cut -d "=" -f 2)
@@ -14,6 +16,10 @@ job_name=$(eval ${jobNameCmd}); retcode=$?
 
 while [ -z "$job_name" ]; do
   sleep 5
+  job_retry_count=$((job_retry_count+1))
+    if [[ "$job_retry_count" -eq "10" ]]; then
+      echo "unable to get JOB_NAME"; exit 1;
+    fi
   job_name=$(eval ${jobNameCmd});
 done
 chmod 755 ../openebs-konvoy-e2e/utils/error_handler
@@ -38,7 +44,11 @@ while true; do
   cstate=$(eval ${containerStateCmd}); rc=$?
   if [[ $rc -eq 0 && ! $cstate ]]; then
     sleep 10
-    else if [[ $rc -eq 0 && ! -z $cstate ]]; then
+    container_retry_count=$((container_retry_count+1))
+    if [[ "$container_retry_count" -eq "10" ]]; then
+      echo "unable to get CONTAINER-STATUS"; exit 1;
+    fi
+    elif [[ $rc -eq 0 && ! -z $cstate ]]; then
       if [[ ! $cstate =~ 'terminated' ]]; then
         sleep 10
       else break;
@@ -57,7 +67,11 @@ while true; do
     else break;
     fi
   else
-    echo "unable to get litmus job status"; exit 1
+    sleep 10
+    job_state_retry_count=$((job_state_retry_count+1))
+    if [[ "$job_state_retry_count" -eq "10" ]]; then
+      echo "unable to get litmus job status"; exit 1;
+    fi
   fi
 done
 echo "Litmus test run Job has completed"


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>

-  resolved typo in testcase name in replace blockdevice script.
- modified the typo in temporary file name in pool-expansion script.
- Modified the litmus_job_runner util to limit no of retries for getting litmus job names