### PR TITLE
refact(script): Change the pooling sequence in chaos stage

### DIFF
--- a/openebs-konvoy-e2e/pipelines/OpenEBS-base/stages/4-chaos/LICZ-clone-post-snap-rebuild/clone-post-snap-rebuild
+++ b/openebs-konvoy-e2e/pipelines/OpenEBS-base/stages/4-chaos/LICZ-clone-post-snap-rebuild/clone-post-snap-rebuild
@@ -22,7 +22,7 @@ present_dir=$(pwd)
 echo $present_dir
 
 #bash openebs-konvoy-e2e/utils/e2e-cr jobname:clone-post-snap-rebuild jobphase:Waiting
-bash openebs-konvoy-e2e/utils/pooling jobname:snap-rebuild-single-rep
+bash openebs-konvoy-e2e/utils/pooling jobname:snap-rebuild-multiple-rep
 bash openebs-konvoy-e2e/utils/e2e-cr jobname:clone-post-snap-rebuild jobphase:Running init_time:"$current_time" jobid:"$job_id" pipelineid:"$pipeline_id" testcaseid:"$case_id" openebs_version:"$releaseTag"
 #bash openebs-konvoy-e2e/utils/e2e-cr jobname:clone-during-snap-rebuild jobphase:Waiting
 #bash openebs-konvoy-e2e/utils/e2e-cr jobname:clone-pre-snap-rebuild jobphase:Waiting

--- a/openebs-konvoy-e2e/pipelines/OpenEBS-base/stages/6-csi-infra-setup/AWES-cstor-operator/cstor-operator
+++ b/openebs-konvoy-e2e/pipelines/OpenEBS-base/stages/6-csi-infra-setup/AWES-cstor-operator/cstor-operator
@@ -5,7 +5,7 @@ node_name=$(sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 
 echo $node_name
 sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port "kubectl taint nodes $node_name infra-aid-"
 
-sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd e2e-konvoy && bash openebs-konvoy-e2e/pipelines/OpenEBS-base/stages/6-csi-infra-setup/AWES-cstor-operator/cstor-operator node '"'$CI_JOB_ID'"'' '"'$CI_PIPELINE_ID'"' '"'$CI_COMMIT_SHA'"' '"'$RELEASE_TAG'"' '"'$CSPC_OPERATOR_IMAGE'"'
+sshpass -p $pass ssh -o StrictHostKeyChecking=no $user@$ip -p $port 'cd e2e-konvoy && bash openebs-konvoy-e2e/pipelines/OpenEBS-base/stages/6-csi-infra-setup/AWES-cstor-operator/cstor-operator node '"'$CI_JOB_ID'"'' '"'$CI_PIPELINE_ID'"' '"'$CI_COMMIT_SHA'"' '"'$RELEASE_TAG'"'
 }
 
 node() {
@@ -15,7 +15,6 @@ pipeline_id=$(echo $2)
 case_id=AWES
 commit_id=$(echo $3)
 releaseTag=$(echo $4)
-cspc_operator_image=$(echo $5)
 source ~/.profile
 gittoken=$(echo "$github_token")
 
@@ -39,7 +38,7 @@ cd litmus
 
 cp providers/cstor-operator/run_litmus_test.yaml cstor_operator.yml
 
-sed -i -e "/name: CSPC_OPERATOR_IMAGE/{n;s/.*/            value: ${cspc_operator_image}/g}" cstor_operator.yml
+sed -i -e "/name: CSPC_OPERATOR_IMAGE/{n;s/.*/            value: ${releaseTag}/g}" cstor_operator.yml
 
 cat cstor_operator.yml
 
@@ -68,7 +67,7 @@ fi
 }
 
 if [ "$1" == "node" ];then
-  node $2 $3 $4 $5 $6
+  node $2 $3 $4 $5
 else
   pod
 fi


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>
- This PR changes the pooling seqence for the jobs in chaos stage.
- Before `snap rebuild multiple replica` and `clone post snap rebuild` jobs were running parallely and because of that we may end up applying the netem delay rule at the same time in pipeline which will leads to the following error.

`
fatal: [127.0.0.1]: FAILED! => {"changed": true, "cmd": "kubectl exec -it cstor-block-disk-pool-stripe-k17l-6885d4565-rd4zn -n openebs --container cstor-pool -- bash -c \"tc qdisc add dev eth0 root netem loss 100.00\"", "delta": "0:00:01.123630", "end": "2020-07-01 05:57:31.895155", "msg": "non-zero return code", "rc": 2, "start": "2020-07-01 05:57:30.771525", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\nRTNETLINK answers: File exists\ncommand terminated with exit code 2", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "RTNETLINK answers: File exists", "command terminated with exit code 2"], "stdout": "", "stdout_lines": []}
`

- Now this PR changes makes these two jobs running sequentially.