### PR TITLE
refact(script): modified the sed command to provide secret values

### DIFF
--- a/openebs-konvoy-e2e/pipelines/OpenEBS-base/stages/5-infra-chaos/RACV-node-failure-cstor/node-failure-cstor
+++ b/openebs-konvoy-e2e/pipelines/OpenEBS-base/stages/5-infra-chaos/RACV-node-failure-cstor/node-failure-cstor
@@ -135,6 +135,9 @@ cp experiments/chaos/node_failure/run_litmus_test.yml run_node_failure.yml
 
 sed -i -e 's/value: app-percona-ns/value: node-failure-cstor/g' \
 -e 's/password:/password: cGFzc3dvcmQ=/g' \
+
+-e 's/passwordNode:/passwordNode: UmFuZG9t/g' \
+
 -e 's/name=percona/app=node-failure-cstor/g' run_node_failure.yml
 
 sed -i '/name: APP_PVC/{n;s/.*/            value: openebs-busybox/}' run_node_failure.yml

--- a/openebs-konvoy-e2e/pipelines/OpenEBS-base/stages/9-csi-infra-chaos/KAPB-node-failure-csi-cstor/node-failure-csi-cstor
+++ b/openebs-konvoy-e2e/pipelines/OpenEBS-base/stages/9-csi-infra-chaos/KAPB-node-failure-csi-cstor/node-failure-csi-cstor
@@ -108,6 +108,7 @@ cp experiments/chaos/node_failure/run_litmus_test.yml run_node_failure_csi.yml
 
 sed -i -e 's/value: app-percona-ns/value: node-failure-csi-cstor/g' \
 -e 's/password:/password: cGFzc3dvcmQ=/g' \
+-e 's/passwordNode:/passwordNode: UmFuZG9t/g' \
 -e 's/name: node-failure/name: node-failure-csi-cstor/g' \
 -e 's/name=percona/app=node-failure-csi-cstor/g' run_node_failure_csi.yml
 


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman.gupta@mayadata.io>

Fixes: https://github.com/openebs/e2e-tests/issues/512
- This PR adds some random password as a node password, so that kubernetes job creation will not fail due to nil value in secret.
- As this secret is not going to be used in konvoy pipeline, we can ignore this secret for node password.